### PR TITLE
Add OpenFaaS to examples

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -41,4 +41,4 @@ A little background on understanding of serverless technologies, infrastructure 
 - [KNative](https://cloud.google.com/knative/)
 - [Kubeless](https://kubeless.io/)
 - [Serverless](https://serverless.com/)  
-
+- [OpenFaaS](https://www.openfaas.com/)

--- a/docs/01-serverless-introduction.md
+++ b/docs/01-serverless-introduction.md
@@ -15,7 +15,7 @@ The first-class integration provision for to their other service offerings _(e.g
 help serverless approaches address larger architectural concerns seamlessly. 
 Apart from these mainstream cloud solution providers there are options to host serverless on premise or on your kubernetes clusters.  
 Apache OpenWhisk is an open source serverless hosting option.  If you want to run serverless on your kubernetes cluster, 
-there are options like KNative and Kubeless. Frameworks like serverless.com have made building, bundling serverless apps 
+there are options like KNative, Kubeless and OpenFaaS. Frameworks like serverless.com have made building, bundling serverless apps 
 simpler. They also provide monitoring options.
 
 ### AWS Lambda


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

Thanks for your guide on Terraform. I noticed that you didn't mention OpenFaaS, which is one of the most popular Kubernetes options on the Cloud Native Landscape, probably still having the highest amount of stars and [a very active community](https://kenfdev.o6s.io/github-stats-page#/)

The community would appreciate it if you were to merge this PR and add OpenFaaS to your list.

On a separate note, you might also find our newer [faasd](https://github.com/openfaas/faasd) project interesting, which is compatible with openfaas, but runs on a single VM (it also has terraform integration). faasd can be run for around 3 EUR / mo on Hetzner.

* [Terraform for faasd](https://www.openfaas.com/blog/faasd-tls-terraform/)
* [Provider for OpenFaaS REST API](https://github.com/ewilde/terraform-provider-openfaas)
